### PR TITLE
Update hexedit.c

### DIFF
--- a/hexedit.c
+++ b/hexedit.c
@@ -273,7 +273,7 @@ void hexedit (uint16_t offset)
                     mode = MODE_HEX;
                     col = FIRST_HEX_COL + 3 * byte;
                 }
-            }
+            }    /* fall through */
             default:
             {
                 if (mode == MODE_HEX)


### PR DESCRIPTION
`E:\Programme\Arduino\portable\sketchbook\libraries\mcurses\hexedit.c: In function 'hexedit':
E:\Programme\Arduino\portable\sketchbook\libraries\mcurses\hexedit.c:266:20: warning: this statement may fall through [-Wimplicit-fallthrough=]
  266 |                 if (mode == MODE_HEX)
      |                    ^
E:\Programme\Arduino\portable\sketchbook\libraries\mcurses\hexedit.c:277:13: note: here
  277 |             default:
      |             ^~~~~~~
`