### PR TITLE
Update mcurses.c

### DIFF
--- a/mcurses.c
+++ b/mcurses.c
@@ -76,7 +76,7 @@ void setFunction_putchar(void (*functionPoitner)(uint8_t ch))
 
 static uint_fast8_t mcurses_phyio_init (void)
 {
-
+  return 0;
 }
 
 /*---------------------------------------------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
`E:\Programme\Arduino\portable\sketchbook\libraries\mcurses\mcurses.c: In function 'mcurses_phyio_init':
E:\Programme\Arduino\portable\sketchbook\libraries\mcurses\mcurses.c:80:1: warning: no return statement in function returning non-void [-Wreturn-type]
   80 | }
`